### PR TITLE
Fix getNextDay() for days with DST change

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,5 +4,6 @@
 	<classpathentry kind="src" path="src_test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="lib" path="lib/bcprov-jdk15on-154.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/src/routines/TimestampUtil.java
+++ b/src/routines/TimestampUtil.java
@@ -40,7 +40,7 @@ public class TimestampUtil {
     	c.set(java.util.Calendar.MINUTE, 0);
     	c.set(java.util.Calendar.SECOND, 0);
     	c.set(java.util.Calendar.MILLISECOND, 0);
-    	c.add(java.util.Calendar.HOUR, 24);
+    	c.add(java.util.Calendar.DATE, 1);
     	return c.getTime();
     }
     

--- a/src_test/TestRoutines.java
+++ b/src_test/TestRoutines.java
@@ -1,3 +1,5 @@
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.math.BigDecimal;
@@ -6,13 +8,14 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import org.junit.Test;
+
 import routines.GenericDateUtil;
 import routines.NumberUtil;
 import routines.RegexUtil;
 import routines.StringCrypt;
 import routines.StringUtil;
 import routines.TimestampUtil;
-
 
 public class TestRoutines {
 
@@ -70,6 +73,29 @@ public class TestRoutines {
 		System.out.println(TimestampUtil.getDateAsInt(d3));
 	}
 	
+	@Test
+	public void testGetNextDay() throws ParseException {
+		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+
+		Date test1 = sdf.parse("2002-01-01");
+		Date result1 = sdf.parse("2002-01-02");
+		assertEquals(result1, TimestampUtil.getNextDay(test1));
+
+		Date test2 = sdf.parse("2002-12-31");
+		Date result2 = sdf.parse("2003-01-01");
+		assertEquals(result2, TimestampUtil.getNextDay(test2));
+
+		// Start of DST in CEST
+		Date test3 = sdf.parse("2016-03-27");
+		Date result3 = sdf.parse("2016-03-28");
+		assertEquals(result3, TimestampUtil.getNextDay(test3));
+
+		// End of DST in CEST
+		Date test4 = sdf.parse("2016-10-30");
+		Date result4 = sdf.parse("2016-10-31");
+		assertEquals(result4, TimestampUtil.getNextDay(test4));
+	}
+
 	public static void testRemoveMultipleSpaces() {
 		String test = "\nJan Lolling  has spaces    X ";
 		System.out.println(StringUtil.reduceMultipleSpacesToOne(test));

--- a/src_test/TestRoutines.java
+++ b/src_test/TestRoutines.java
@@ -1,14 +1,10 @@
 import java.io.File;
 import java.io.FileFilter;
 import java.math.BigDecimal;
-import java.math.MathContext;
-import java.net.MalformedURLException;
 import java.security.NoSuchAlgorithmException;
-import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Locale;
 
 import routines.GenericDateUtil;
 import routines.NumberUtil;


### PR DESCRIPTION
So far, getNextDay() does not behave well for days that have a clock shift due to daylight saving time (DST). This PR ensures that the date is properly incremented. 

For the recent switch from CEST to CET last Sunday (2016-10-30), we do not advance to 2016-10-31. Instead, we get 2016-10-30 23:00:00.

Please note that the JUnit test case will succeed in UTC even without the fix. In order to reveal the problematic behavior, the test needs to be run e.g. for the timezone Europe/Berlin. I am not sure what is the best way to enforce this, because we probably do not want to run all tests in this timezone.